### PR TITLE
patch drupal/issues/2292125

### DIFF
--- a/includes/unicode.inc
+++ b/includes/unicode.inc
@@ -334,6 +334,10 @@ function _mime_header_decode($matches) {
  *   The input $text, with all HTML entities decoded once.
  */
 function decode_entities($text, $exclude = array()) {
+  if (empty($exclude) && version_compare(phpversion(), '5.0') >= 0) {
+    return html_entity_decode($text, ENT_QUOTES, 'UTF-8');
+  }
+
   static $html_entities;
   if (!isset($html_entities)) {
     include_once './includes/unicode.entities.inc';
@@ -342,11 +346,11 @@ function decode_entities($text, $exclude = array()) {
   // Flip the exclude list so that we can do quick lookups later.
   $exclude = array_flip($exclude);
 
-  // Use a regexp to select all entities in one pass, to avoid decoding 
+  // Use a regexp to select all entities in one pass, to avoid decoding
   // double-escaped entities twice. The PREG_REPLACE_EVAL modifier 'e' is
-  // being used to allow for a callback (see 
+  // being used to allow for a callback (see
   // http://php.net/manual/en/reference.pcre.pattern.modifiers).
-  return preg_replace('/&(#x?)?([A-Za-z0-9]+);/e', '_decode_entities("$1", "$2", "$0", $html_entities, $exclude)', $text);
+  return @preg_replace('/&(#x?)?([A-Za-z0-9]+);/e', '_decode_entities("$1", "$2", "$0", $html_entities, $exclude)', $text);
 }
 
 /**


### PR DESCRIPTION
Patch described in https://www.drupal.org/project/drupal/issues/2292125
PHP 5.5 - preg_replace(): The /e modifier is deprecated, use preg_replace_callback instead in decode_entities() (line 349 of includes/unicode.inc)