### PR TITLE
Fix sess_regenerate for PHP7

### DIFF
--- a/includes/session.inc
+++ b/includes/session.inc
@@ -124,6 +124,7 @@ function sess_write($key, $value) {
  * Called when an anonymous user becomes authenticated or vice-versa.
  */
 function sess_regenerate() {
+  global $user;
   $old_session_id = session_id();
 
   // We code around http://bugs.php.net/bug.php?id=32802 by destroying
@@ -135,7 +136,12 @@ function sess_regenerate() {
     setcookie(session_name(), '', time() - 42000, '/');
   }
 
+  // On PHP7, sess_read($key) is being called with the new session key but not
+  // on PHP5. This failsafe stores the initial user object, which on PHP5 should
+  // be just the same, and restore it later on.
+  $account = $user;
   session_regenerate_id();
+  $user = $account;
 
   db_query("UPDATE {sessions} SET sid = '%s' WHERE sid = '%s'", session_id(), $old_session_id);
 }

--- a/modules/user/user.module
+++ b/modules/user/user.module
@@ -1428,8 +1428,7 @@ function user_authenticate_finalize(&$edit) {
   db_query("UPDATE {users} SET login = %d WHERE uid = %d", $user->login, $user->uid);
 
   // Regenerate the session ID to prevent against session fixation attacks.
-  // TODO: We shouldn't comment this out, but fix sess_regenerate() to work with PHP 7
-  //sess_regenerate();
+  sess_regenerate();
   user_module_invoke('login', $edit, $user);
 }
 


### PR DESCRIPTION
This attempts to improve on #8.

I looked for what's going on with sess_regenerate() and it seems that on PHP7, sess_read($key) is being called with the new session key, while not on PHP5. sess_read() then fails to find the new session so the user is lost.

There's some discussion about this on https://www.drupal.org/forum/support/upgrading-drupal/2016-05-27/drupal-638-in-php-7.

I went for that fix. I thought about it and I think is good enough at this point. I considered doing something different and maybe flagging something on the $user, but would be a similar end result but this would affect other session implementations (i.e. memecache, etc.).

As sess_regenerate is only called in two places in core, I believe this should be safe.

