### PR TITLE
PHP7 warnings fix, opcache_invalidate settings.php

### DIFF
--- a/includes/install.inc
+++ b/includes/install.inc
@@ -236,6 +236,11 @@ function drupal_rewrite_settings($settings = array(), $prefix = '') {
     if ($fp && fwrite($fp, $buffer) === FALSE) {
       drupal_set_message(st('Failed to modify %settings, please verify the file permissions.', array('%settings' => $settings_file)), 'error');
     }
+    fclose($fp);
+    // Invalidate the cache of the settings file so next request read the newly modified one
+    if (function_exists('opcache_invalidate')) {
+      opcache_invalidate($settings_file, TRUE);
+    }
   }
   else {
     drupal_set_message(st('Failed to open %settings, please verify the file permissions.', array('%settings' => $default_settings)), 'error');

--- a/includes/install.mysqli.inc
+++ b/includes/install.mysqli.inc
@@ -31,6 +31,7 @@ function drupal_test_mysqli($url, &$success) {
   $url['pass'] = isset($url['pass']) ? urldecode($url['pass']) : '';
   $url['host'] = urldecode($url['host']);
   $url['path'] = urldecode($url['path']);
+  $url['port'] = isset($url['port']) ? $url['port'] : NULL;
 
   $connection = mysqli_init();
   @mysqli_real_connect($connection, $url['host'], $url['user'], $url['pass'], substr($url['path'], 1), $url['port'], NULL, MYSQLI_CLIENT_FOUND_ROWS);


### PR DESCRIPTION
It was the opcode cache which was not being invalidated fast enough.

Fixes #11 and prevent one warning