### PR TITLE
Add update hook to update .htaccess in files directory on existing sites

### DIFF
--- a/modules/system/system.install
+++ b/modules/system/system.install
@@ -2746,6 +2746,17 @@ function system_update_6056() {
 }
 
 /**
+ * Overwrite the .htaccess in the files and temp directory for PHP 7.
+ */
+function system_update_6057() {
+  include_once './includes/file.inc';
+  $ret = array();
+  file_create_htaccess(file_directory_path(), NULL, TRUE);
+  file_create_htaccess(file_directory_temp(), NULL, TRUE);
+  return $ret;
+}
+
+/**
  * @} End of "defgroup updates-6.x-extra".
  * The next series of updates should start at 7000.
  */


### PR DESCRIPTION
This is to fix #16 

I'm a little unsure about this. I've never customized the .htaccess file in the files directory, but I wonder if others might have? I don't want to wipe out their changes, but I don't want to leave sites on PHP vulnerable to attack.