### PR TITLE
Remplace $ by jQuery to avoid JS errors if another framework is in use

### DIFF
--- a/misc/autocomplete.js
+++ b/misc/autocomplete.js
@@ -4,16 +4,16 @@
  */
 Drupal.behaviors.autocomplete = function (context) {
   var acdb = [];
-  $('input.autocomplete:not(.autocomplete-processed)', context).each(function () {
+  jQuery('input.autocomplete:not(.autocomplete-processed)', context).each(function () {
     var uri = this.value;
     if (!acdb[uri]) {
       acdb[uri] = new Drupal.ACDB(uri);
     }
-    var input = $('#' + this.id.substr(0, this.id.length - 13))
+    var input = jQuery('#' + this.id.substr(0, this.id.length - 13))
       .attr('autocomplete', 'OFF')[0];
-    $(input.form).submit(Drupal.autocompleteSubmit);
+    jQuery(input.form).submit(Drupal.autocompleteSubmit);
     new Drupal.jsAC(input, acdb[uri]);
-    $(this).addClass('autocomplete-processed');
+    jQuery(this).addClass('autocomplete-processed');
   });
 };
 
@@ -22,7 +22,7 @@ Drupal.behaviors.autocomplete = function (context) {
  * and closes the suggestions popup when doing so.
  */
 Drupal.autocompleteSubmit = function () {
-  return $('#autocomplete').each(function () {
+  return jQuery('#autocomplete').each(function () {
     this.owner.hidePopup();
   }).size() == 0;
 };
@@ -35,7 +35,7 @@ Drupal.jsAC = function (input, db) {
   this.input = input;
   this.db = db;
 
-  $(this.input)
+  jQuery(this.input)
     .keydown(function (event) { return ac.onkeydown(this, event); })
     .keyup(function (event) { ac.onkeyup(this, event); })
     .blur(function () { ac.hidePopup(); ac.db.cancel(); });
@@ -113,7 +113,7 @@ Drupal.jsAC.prototype.selectDown = function () {
     this.highlight(this.selected.nextSibling);
   }
   else {
-    var lis = $('li', this.popup);
+    var lis = jQuery('li', this.popup);
     if (lis.size() > 0) {
       this.highlight(lis.get(0));
     }
@@ -134,9 +134,9 @@ Drupal.jsAC.prototype.selectUp = function () {
  */
 Drupal.jsAC.prototype.highlight = function (node) {
   if (this.selected) {
-    $(this.selected).removeClass('selected');
+    jQuery(this.selected).removeClass('selected');
   }
-  $(node).addClass('selected');
+  jQuery(node).addClass('selected');
   this.selected = node;
 };
 
@@ -144,7 +144,7 @@ Drupal.jsAC.prototype.highlight = function (node) {
  * Unhighlights a suggestion
  */
 Drupal.jsAC.prototype.unhighlight = function (node) {
-  $(node).removeClass('selected');
+  jQuery(node).removeClass('selected');
   this.selected = false;
 };
 
@@ -160,7 +160,7 @@ Drupal.jsAC.prototype.hidePopup = function (keycode) {
   var popup = this.popup;
   if (popup) {
     this.popup = null;
-    $(popup).fadeOut('fast', function() { $(popup).remove(); });
+    jQuery(popup).fadeOut('fast', function() { jQuery(popup).remove(); });
   }
   this.selected = false;
 };
@@ -171,18 +171,18 @@ Drupal.jsAC.prototype.hidePopup = function (keycode) {
 Drupal.jsAC.prototype.populatePopup = function () {
   // Show popup
   if (this.popup) {
-    $(this.popup).remove();
+    jQuery(this.popup).remove();
   }
   this.selected = false;
   this.popup = document.createElement('div');
   this.popup.id = 'autocomplete';
   this.popup.owner = this;
-  $(this.popup).css({
+  jQuery(this.popup).css({
     marginTop: this.input.offsetHeight +'px',
     width: (this.input.offsetWidth - 4) +'px',
     display: 'none'
   });
-  $(this.input).before(this.popup);
+  jQuery(this.input).before(this.popup);
 
   // Do search
   this.db.owner = this;
@@ -203,22 +203,22 @@ Drupal.jsAC.prototype.found = function (matches) {
   var ac = this;
   for (key in matches) {
     var li = document.createElement('li');
-    $(li)
+    jQuery(li)
       .html('<div>'+ matches[key] +'</div>')
       .mousedown(function () { ac.select(this); })
       .mouseover(function () { ac.highlight(this); })
       .mouseout(function () { ac.unhighlight(this); });
     li.autocompleteValue = key;
-    $(ul).append(li);
+    jQuery(ul).append(li);
   }
 
   // Show popup with matches, if any
   if (this.popup) {
     if (ul.childNodes.length > 0) {
-      $(this.popup).empty().append(ul).show();
+      jQuery(this.popup).empty().append(ul).show();
     }
     else {
-      $(this.popup).css({visibility: 'hidden'});
+      jQuery(this.popup).css({visibility: 'hidden'});
       this.hidePopup();
     }
   }
@@ -227,12 +227,12 @@ Drupal.jsAC.prototype.found = function (matches) {
 Drupal.jsAC.prototype.setStatus = function (status) {
   switch (status) {
     case 'begin':
-      $(this.input).addClass('throbbing');
+      jQuery(this.input).addClass('throbbing');
       break;
     case 'cancel':
     case 'error':
     case 'found':
-      $(this.input).removeClass('throbbing');
+      jQuery(this.input).removeClass('throbbing');
       break;
   }
 };
@@ -276,7 +276,7 @@ Drupal.ACDB.prototype.search = function (searchString) {
     db.owner.setStatus('begin');
 
     // Ajax GET request for autocompletion
-    $.ajax({
+    jQuery.ajax({
       type: "GET",
       url: db.uri +'/'+ Drupal.encodeURIComponent(searchString),
       dataType: 'json',

--- a/misc/drupal.js
+++ b/misc/drupal.js
@@ -26,22 +26,22 @@
    *
    * See https://github.com/jquery/jquery/issues/2432
    */
-  if ($.ajaxPrefilter) {
+  if (jQuery.ajaxPrefilter) {
     // For newer versions of jQuery, use an Ajax prefilter to prevent
     // auto-executing script tags from untrusted domains. This is similar to the
     // fix that is built in to jQuery 3.0 and higher.
-    $.ajaxPrefilter(function (s) {
+      jQuery.ajaxPrefilter(function (s) {
       if (s.crossDomain) {
         s.contents.script = false;
       }
     });
   }
-  else if ($.httpData) {
+  else if (jQuery.httpData) {
     // For the version of jQuery that ships with Drupal core, override
     // jQuery.httpData to prevent auto-detecting "script" data types from
     // untrusted domains.
-    var jquery_httpData = $.httpData;
-    $.httpData = function (xhr, type, s) {
+    var jquery_httpData = jQuery.httpData;
+      jQuery.httpData = function (xhr, type, s) {
       // @todo Consider backporting code from newer jQuery versions to check for
       //   a cross-domain request here, rather than using Drupal.urlIsLocal() to
       //   block scripts from all URLs that are not on the same site.
@@ -54,7 +54,7 @@
       }
       return jquery_httpData.call(this, xhr, type, s);
     };
-    $.httpData.prototype = jquery_httpData.prototype;
+    jQuery.httpData.prototype = jquery_httpData.prototype;
   }
 })();
 
@@ -324,21 +324,21 @@ Drupal.parseJson = function (data) {
 Drupal.freezeHeight = function () {
   Drupal.unfreezeHeight();
   var div = document.createElement('div');
-  $(div).css({
+  jQuery(div).css({
     position: 'absolute',
     top: '0px',
     left: '0px',
     width: '1px',
-    height: $('body').css('height')
+    height: jQuery('body').css('height')
   }).attr('id', 'freeze-height');
-  $('body').append(div);
+  jQuery('body').append(div);
 };
 
 /**
  * Unfreeze the body height
  */
 Drupal.unfreezeHeight = function () {
-  $('#freeze-height').remove();
+  jQuery('#freeze-height').remove();
 };
 
 /**
@@ -377,7 +377,7 @@ Drupal.getSelection = function (element) {
  */
 Drupal.ahahError = function(xmlhttp, uri) {
   if (xmlhttp.status == 200) {
-    if (jQuery.trim($(xmlhttp.responseText).text())) {
+    if (jQuery.trim(jQuery(xmlhttp.responseText).text())) {
       var message = Drupal.t("An error occurred. \n@uri\n@text", {'@uri': uri, '@text': xmlhttp.responseText });
     }
     else {
@@ -393,11 +393,11 @@ Drupal.ahahError = function(xmlhttp, uri) {
 // Global Killswitch on the <html> element
 if (Drupal.jsEnabled) {
   // Global Killswitch on the <html> element
-  $(document.documentElement).addClass('js');
+  jQuery(document.documentElement).addClass('js');
   // 'js enabled' cookie
   document.cookie = 'has_js=1; path=/';
   // Attach all behaviors.
-  $(document).ready(function() {
+  jQuery(document).ready(function() {
     Drupal.attachBehaviors(this);
   });
 }


### PR DESCRIPTION
Fix Javascript errors when Drupal is installed with multiple JS Frameworks (for example, jQuery and PrototypeJS in tested case).