### PR TITLE
Fix deprecation warnings for each()

### DIFF
--- a/includes/menu.inc
+++ b/includes/menu.inc
@@ -385,7 +385,8 @@ function _menu_load_objects(&$item, &$map) {
           // 'load arguments' in the hook_menu() entry, but they need
           // some processing. In this case the $function is the key to the
           // load_function array, and the value is the list of arguments.
-          list($function, $args) = each($function);
+          $args = current($function);
+          $function = key($function);
           $load_functions[$index] = $function;
 
           // Some arguments are placeholders for dynamic items to process.
@@ -1560,7 +1561,9 @@ function menu_set_active_trail($new_trail = NULL) {
     }
 
     $tree = menu_tree_page_data(menu_get_active_menu_name());
-    list($key, $curr) = each($tree);
+
+    $curr = current($tree);
+    next($tree);
 
     while ($curr) {
       // Terminate the loop when we find the current path in the active trail.
@@ -1574,7 +1577,8 @@ function menu_set_active_trail($new_trail = NULL) {
           $trail[] = $curr['link'];
           $tree = $curr['below'] ? $curr['below'] : array();
         }
-        list($key, $curr) = each($tree);
+        $curr = current($tree);
+        next($tree);
       }
     }
     // Make sure the current page is in the trail (needed for the page title),

--- a/modules/book/book.module
+++ b/modules/book/book.module
@@ -545,11 +545,13 @@ function book_prev($book_link) {
     return NULL;
   }
   $flat = book_get_flat_menu($book_link);
-  // Assigning the array to $flat resets the array pointer for use with each().
+  reset($flat);
   $curr = NULL;
   do {
     $prev = $curr;
-    list($key, $curr) = each($flat);
+    $curr = current($flat);
+    $key = key($flat);
+    next($flat);
   } while ($key && $key != $book_link['mlid']);
 
   if ($key == $book_link['mlid']) {
@@ -574,9 +576,10 @@ function book_prev($book_link) {
  */
 function book_next($book_link) {
   $flat = book_get_flat_menu($book_link);
-  // Assigning the array to $flat resets the array pointer for use with each().
+  reset($flat);
   do {
-    list($key, $curr) = each($flat);
+    $key = key($flat);
+    next($flat);
   } while ($key && $key != $book_link['mlid']);
   if ($key == $book_link['mlid']) {
     return current($flat);


### PR DESCRIPTION
As stated in #22 the each iterator is deprecated in PHP 7.2 and throws warnings. I used Ayesh's patch for Drupal 7 (https://www.drupal.org/project/drupal/issues/2925449) and backported it to D6.
