### PR TITLE
Group by missing s.timestamp

### DIFF
--- a/modules/user/user.module
+++ b/modules/user/user.module
@@ -818,7 +818,7 @@ function user_block($op = 'list', $delta = 0, $edit = array()) {
           // Display a list of currently online users.
           $max_users = variable_get('user_block_max_list_count', 10);
           if ($authenticated_count && $max_users) {
-            $authenticated_users = db_query_range('SELECT u.uid, u.name, MAX(s.timestamp) AS timestamp FROM {users} u INNER JOIN {sessions} s ON u.uid = s.uid WHERE s.timestamp >= %d AND s.uid > 0 GROUP BY u.uid, u.name ORDER BY s.timestamp DESC', $interval, 0, $max_users);
+            $authenticated_users = db_query_range('SELECT u.uid, u.name, MAX(s.timestamp) AS timestamp FROM {users} u INNER JOIN {sessions} s ON u.uid = s.uid WHERE s.timestamp >= %d AND s.uid > 0 GROUP BY u.uid, u.name, s.timestamp ORDER BY s.timestamp DESC', $interval, 0, $max_users);
             while ($account = db_fetch_object($authenticated_users)) {
               $items[] = $account;
             }


### PR DESCRIPTION
Postgres requires s.timestamp to be in the group by statement.