### PR TITLE
Issue #3052207: Switch db_version_compare() to using $db_type rather than $db_url

### DIFF
--- a/includes/database.inc
+++ b/includes/database.inc
@@ -353,9 +353,9 @@ $db_mysql8_reserved_keywords = array(
  *   TRUE if version check passes; otherwise FALSE.
 */
 function db_version_compare($driver, $version, $operator = '>=') {
-  global $db_url;
+  global $db_type;
 
-  if (substr($db_url, 0, strlen($driver)) === $driver) {
+  if (substr($db_type, 0, strlen($driver)) === $driver) {
     if (version_compare(db_version(), $version, $operator)) {
       return TRUE;
     }


### PR DESCRIPTION
I haven't tested this yet, just putting up to show the idea.

Attempt to fix https://www.drupal.org/project/d6lts/issues/3052207

The issue is introduced by #35 - @f1mishutka do you have any ideas?