### PR TITLE
Fix Undefined property: stdClass:: in common.inc

### DIFF
--- a/includes/common.inc
+++ b/includes/common.inc
@@ -1557,7 +1557,7 @@ function url($path = NULL, $options = array()) {
     $path = '';
   }
   elseif (!empty($path) && !$options['alias']) {
-    $path = drupal_get_path_alias($path, isset($options['language']) ? $options['language']->language : '');
+    $path = drupal_get_path_alias($path, (isset($options['language']) && isset($options['language']->language)) ? $options['language']->language : '');
     // Strip leading slashes from internal paths to prevent them becoming external
     // URLs without protocol. /example.com should not be turned into
     // //example.com.


### PR DESCRIPTION
I'm getting this notice:

> Notice: Undefined property: stdClass::$language in includes/common.inc on line 1560