### PR TITLE
Fix warning in PHP 7.2: Attempting to count() non-countable types.

### DIFF
--- a/update.php
+++ b/update.php
@@ -345,7 +345,7 @@ function update_results_page() {
               $output .= '<li class="failure"><strong>Failed:</strong> '. $query['query'] .'</li>';
             }
           }
-          if (!count($queries)) {
+          if (empty($queries)) {
             $output .= '<li class="none">No queries</li>';
           }
           $output .= '</ul>';


### PR DESCRIPTION
I was performing an update using www.example.com/update.php. I was calling a CCK method in `hook_update_N()` which threw errors. Then `update.php` itself threw a warning about attempting to count() a non-countable type. This pull request fixes it.

See https://github.com/d6lts/cck/pull/4 for the CCK error I ran into.
