### PR TITLE
Fix fatal errors on PHP8

### DIFF
--- a/includes/common.inc
+++ b/includes/common.inc
@@ -213,7 +213,7 @@ function drupal_add_feed($url = NULL, $title = '') {
  */
 function drupal_get_feeds($delimiter = "\n") {
   $feeds = drupal_add_feed();
-  return implode($feeds, $delimiter);
+  return implode($delimiter, $feeds);
 }
 
 /**

--- a/misc/typo3/phar-stream-wrapper/README.md
+++ b/misc/typo3/phar-stream-wrapper/README.md
@@ -1,12 +1,13 @@
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/TYPO3/phar-stream-wrapper/badges/quality-score.png?b=v2)](https://scrutinizer-ci.com/g/TYPO3/phar-stream-wrapper/?branch=v2)
 [![Travis CI Build Status](https://travis-ci.org/TYPO3/phar-stream-wrapper.svg?branch=v2)](https://travis-ci.org/TYPO3/phar-stream-wrapper)
+[![AppVeyor Build status](https://ci.appveyor.com/api/projects/status/q4ls5tg4w1d6sf4i/branch/v2?svg=true)](https://ci.appveyor.com/project/ohader/phar-stream-wrapper)
 
 # PHP Phar Stream Wrapper
 
 ## Abstract & History
 
 Based on Sam Thomas' findings concerning
-[insecure deserialization in combination with obfuscation strategies](https://blog.secarma.co.uk/labs/near-phar-dangerous-unserialization-wherever-you-are)
+[insecure deserialization in combination with obfuscation strategies](https://www.secarma.com/labs/near-phar-dangerous-unserialization-wherever-you-are.html)
 allowing to hide Phar files inside valid image resources, the TYPO3 project
 decided back then to introduce a `PharStreamWrapper` to intercept invocations
 of the `phar://` stream in PHP and only allow usage for defined locations in
@@ -21,9 +22,11 @@ and has been addressed concerning the specific attack vector and for this generi
 `PharStreamWrapper` in TYPO3 versions 7.6.30 LTS, 8.7.17 LTS and 9.3.1 on 12th
 July 2018.
 
-* https://typo3.org/security/advisory/typo3-core-sa-2018-002/
 * https://blog.secarma.co.uk/labs/near-phar-dangerous-unserialization-wherever-you-are
 * https://youtu.be/GePBmsNJw6Y
+* https://typo3.org/security/advisory/typo3-psa-2018-001/
+* https://typo3.org/security/advisory/typo3-psa-2019-007/
+* https://typo3.org/security/advisory/typo3-psa-2019-008/
 
 ## License
 

--- a/misc/typo3/phar-stream-wrapper/composer.json
+++ b/misc/typo3/phar-stream-wrapper/composer.json
@@ -6,14 +6,16 @@
     "homepage": "https://typo3.org/",
     "keywords": ["php", "phar", "stream-wrapper", "security"],
     "require": {
-        "php": "^5.3.3|^7.0",
-        "ext-fileinfo": "*",
+        "php": "^5.3.3 || ^7.0",
         "ext-json": "*",
-        "brumann/polyfill-unserialize": "^1.0"
+        "brumann/polyfill-unserialize": "^1.0 || ^2.0"
     },
     "require-dev": {
         "ext-xdebug": "*",
         "phpunit/phpunit": "^4.8.36"
+    },
+    "suggest": {
+        "ext-fileinfo": "For PHP builtin file type guessing, otherwise uses internal processing"
     },
     "autoload": {
         "psr-4": {

--- a/misc/typo3/phar-stream-wrapper/src/Helper.php
+++ b/misc/typo3/phar-stream-wrapper/src/Helper.php
@@ -31,9 +31,9 @@ class Helper
         if (function_exists('opcache_reset')
             && function_exists('opcache_get_status')
         ) {
-            $status = opcache_get_status();
+            $status = @opcache_get_status();
             if (!empty($status['opcache_enabled'])) {
-                opcache_reset();
+                @opcache_reset();
             }
         }
     }
@@ -52,7 +52,7 @@ class Helper
 
         while (count($parts)) {
             $currentPath = implode('/', $parts);
-            if (@is_file($currentPath)) {
+            if (@is_file($currentPath) && realpath($currentPath) !== false) {
                 return $currentPath;
             }
             array_pop($parts);
@@ -106,7 +106,7 @@ class Helper
      * @param string $path File path to process
      * @return string
      */
-    private static function normalizeWindowsPath($path)
+    public static function normalizeWindowsPath($path)
     {
         return str_replace('\\', '/', $path);
     }

--- a/misc/typo3/phar-stream-wrapper/src/PharStreamWrapper.php
+++ b/misc/typo3/phar-stream-wrapper/src/PharStreamWrapper.php
@@ -476,7 +476,7 @@ class PharStreamWrapper
     {
         $arguments = func_get_args();
         array_shift($arguments);
-        $silentExecution = $functionName{0} === '@';
+        $silentExecution = $functionName[0] === '@';
         $functionName = ltrim($functionName, '@');
         $this->restoreInternalSteamWrapper();
 
@@ -500,7 +500,15 @@ class PharStreamWrapper
 
     private function restoreInternalSteamWrapper()
     {
-        stream_wrapper_restore('phar');
+        if (PHP_VERSION_ID < 70324
+            || PHP_VERSION_ID >= 70400 && PHP_VERSION_ID < 70412) {
+            stream_wrapper_restore('phar');
+        } else  {
+            // with https://github.com/php/php-src/pull/6183 (PHP #76943) the
+            // behavior of `stream_wrapper_restore()` did change for
+            // PHP 8.0-RC1, 7.4.12 and 7.3.24
+            @stream_wrapper_restore('phar');
+        }
     }
 
     private function registerStreamWrapper()

--- a/misc/typo3/phar-stream-wrapper/src/Resolver/PharInvocationResolver.php
+++ b/misc/typo3/phar-stream-wrapper/src/Resolver/PharInvocationResolver.php
@@ -14,6 +14,7 @@ namespace TYPO3\PharStreamWrapper\Resolver;
 use TYPO3\PharStreamWrapper\Helper;
 use TYPO3\PharStreamWrapper\Manager;
 use TYPO3\PharStreamWrapper\Phar\Reader;
+use TYPO3\PharStreamWrapper\Phar\ReaderException;
 use TYPO3\PharStreamWrapper\Resolvable;
 
 class PharInvocationResolver implements Resolvable
@@ -59,7 +60,7 @@ class PharInvocationResolver implements Resolvable
     {
         $hasPharPrefix = Helper::hasPharPrefix($path);
         if ($flags === null) {
-            $flags = static::RESOLVE_REALPATH | static::RESOLVE_ALIAS | static::ASSERT_INTERNAL_INVOCATION;
+            $flags = static::RESOLVE_REALPATH | static::RESOLVE_ALIAS;
         }
 
         if ($hasPharPrefix && $flags & static::RESOLVE_ALIAS) {
@@ -147,9 +148,14 @@ class PharInvocationResolver implements Resolvable
             }
             // ensure the possible alias name (how we have been called initially) matches
             // the resolved alias name that was retrieved by the current possible base name
-            $reader = new Reader($currentBaseName);
-            $currentAlias = $reader->resolveContainer()->getAlias();
-            if ($currentAlias !== $possibleAlias) {
+            try {
+                $reader = new Reader($currentBaseName);
+                $currentAlias = $reader->resolveContainer()->getAlias();
+            } catch (ReaderException $exception) {
+                // most probably that was not a Phar file
+                continue;
+            }
+            if (empty($currentAlias) || $currentAlias !== $possibleAlias) {
                 continue;
             }
             $this->addBaseName($currentBaseName);
@@ -215,7 +221,9 @@ class PharInvocationResolver implements Resolvable
         if (isset($this->baseNames[$baseName])) {
             return;
         }
-        $this->baseNames[$baseName] = realpath($baseName);
+        $this->baseNames[$baseName] = Helper::normalizeWindowsPath(
+            realpath($baseName)
+        );
     }
 
     /**

--- a/modules/block/block.admin.inc
+++ b/modules/block/block.admin.inc
@@ -97,6 +97,7 @@ function block_admin_display_form(&$form_state, $blocks, $theme = NULL) {
  * Process main blocks administration form submission.
  */
 function block_admin_display_form_submit($form, &$form_state) {
+  unset($form_state['values']['op'], $form_state['values']['submit'], $form_state['values']['form_token'], $form_state['values']['form_id'], $form_state['values']['form_build_id']);
   foreach ($form_state['values'] as $block) {
     $block['status'] = $block['region'] != BLOCK_REGION_NONE;
     $block['region'] = $block['status'] ? $block['region'] : '';

--- a/modules/filter/filter.module
+++ b/modules/filter/filter.module
@@ -802,7 +802,7 @@ function _filter_htmlcorrector($text) {
       else {
         list($tagname) = preg_split('/\s/', strtolower($value), 2);
         // Closing tag
-        if ($tagname{0} == '/') {
+        if ($tagname[0] == '/') {
           $tagname = substr($tagname, 1);
           // Discard XHTML closing tags for single use tags.
           if (!isset($single_use[$tagname])) {

--- a/modules/search/search.module
+++ b/modules/search/search.module
@@ -724,7 +724,7 @@ function search_parse_query($text) {
   foreach ($matches as $match) {
     $phrase = FALSE;
     // Strip off phrase quotes
-    if ($match[2]{0} == '"') {
+    if ($match[2][0] == '"') {
       $match[2] = substr($match[2], 1, -1);
       $phrase = TRUE;
       $simple = FALSE;


### PR DESCRIPTION
These fatals on PHP8 are all notices (or warnings) in PHP7.4. I've packed all the ones I found* into one PR.

Individual commit messages hold details.

The last commit is an update of the full typo3/phar-stream-wrapper library to 2.2.1. It basically has two PHP7/8 fixes in PharStreamWrapper, plus some other changes for edge cases/Windows that I don't see being a problem. Still works on PHP5.3, and the only reason for the minor version bump is a change in dependencies. (Optional upgrade of a supporting library, which I ignored.)


\* except PRs #62 and #30

\* Mostly by running simpletest on PHP8. If you want to publish https://github.com/rmuit/simpletest as D6LTS, feel free to.