### PR TITLE
Fix notices (non-fatal, so fixing optional)

### DIFF
--- a/includes/common.inc
+++ b/includes/common.inc
@@ -2050,7 +2050,7 @@ function _drupal_build_css_path($matches, $base = NULL) {
   }
 
   // Prefix with base and remove '../' segments where possible.
-  $path = $_base . $matches[1];
+  $path = $_base . (isset($matches[1]) ? $matches[1]: '');
   $last = '';
   while ($path != $last) {
     $last = $path;

--- a/includes/common.inc
+++ b/includes/common.inc
@@ -1179,7 +1179,7 @@ function format_xml_elements($array) {
   $output = '';
   foreach ($array as $key => $value) {
     if (is_numeric($key)) {
-      if ($value['key']) {
+      if (!empty($value['key'])) {
         $output .= ' <'. $value['key'];
         if (isset($value['attributes']) && is_array($value['attributes'])) {
           $output .= drupal_attributes($value['attributes']);

--- a/includes/common.inc
+++ b/includes/common.inc
@@ -2041,6 +2041,19 @@ function drupal_build_css_cache($types, $filename) {
  * Helper function for drupal_build_css_cache().
  *
  * This function will prefix all paths within a CSS file.
+ *
+ * @param array|null $matches
+ *   A 'matches' array as would be populated by e.g. preg_match() - meaning
+ *   $matches[0] has text that matched the full pattern and $matches[1] has
+ *   text that matched the first captured parenthesized subpattern. We assume
+ *   $matchesIf NULL,
+ *   then don't return anything useful; only set the base path for future calls.
+ * @param string|null $base
+ *   The base path to use for prefixing.
+ *
+ * @return string|null
+ *   A CSS path (prefixed, and surrounded with "url()" - or NULL if the first
+ *   parameter was NULL.
  */
 function _drupal_build_css_path($matches, $base = NULL) {
   static $_base;
@@ -2048,9 +2061,12 @@ function _drupal_build_css_path($matches, $base = NULL) {
   if (isset($base)) {
     $_base = $base;
   }
+  if (!isset($matches[1])) {
+    return NULL;
+  }
 
   // Prefix with base and remove '../' segments where possible.
-  $path = $_base . (isset($matches[1]) ? $matches[1]: '');
+  $path = $_base . $matches[1];
   $last = '';
   while ($path != $last) {
     $last = $path;

--- a/includes/database.mysql.inc
+++ b/includes/database.mysql.inc
@@ -192,7 +192,11 @@ function db_result($result) {
     // The mysql_fetch_row function has an optional second parameter $row
     // but that can't be used for compatibility with Oracle, DB2, etc.
     $array = mysql_fetch_row($result);
-    return $array[0];
+    // This function was never meant to be used multiple times on the same
+    // result set (resulting in $array being FALSE). But the above spec is not
+    // absolutely clear about that, so various code is doing it, and PHP < 7.4
+    // didn't emit any PHP Notices. So now, we effectively support it...
+    return isset($array[0]) ? $array[0] : FALSE;
   }
   return FALSE;
 }

--- a/includes/database.mysqli.inc
+++ b/includes/database.mysqli.inc
@@ -192,7 +192,11 @@ function db_result($result) {
     // The mysqli_fetch_row function has an optional second parameter $row
     // but that can't be used for compatibility with Oracle, DB2, etc.
     $array = mysqli_fetch_row($result);
-    return $array[0];
+    // This function was never meant to be used multiple times on the same
+    // result set (resulting in $array being NULL). But the above spec is not
+    // absolutely clear about that, so various code is doing it, and PHP < 7.4
+    // didn't emit any PHP Notices. So now, we effectively support it...
+    return isset($array[0]) ? $array[0] : FALSE;
   }
   return FALSE;
 }

--- a/includes/database.pgsql.inc
+++ b/includes/database.pgsql.inc
@@ -206,7 +206,11 @@ function db_fetch_array($result) {
 function db_result($result) {
   if ($result && pg_num_rows($result) > 0) {
     $array = pg_fetch_row($result);
-    return $array[0];
+    // This function was never meant to be used multiple times on the same
+    // result set (resulting in $array being FALSE). But the above spec is not
+    // absolutely clear about that, so various code is doing it, and PHP < 7.4
+    // didn't emit any PHP Notices. So now, we effectively support it...
+    return isset($array[0]) ? $array[0] : FALSE;
   }
   return FALSE;
 }

--- a/includes/menu.inc
+++ b/includes/menu.inc
@@ -1539,7 +1539,7 @@ function menu_set_active_trail($new_trail = NULL) {
     $item = menu_get_item();
 
     // Check whether the current item is a local task (displayed as a tab).
-    if ($item['tab_parent']) {
+    if (!empty($item['tab_parent'])) {
       // The title of a local task is used for the tab, never the page title.
       // Thus, replace it with the item corresponding to the root path to get
       // the relevant href and title.  For example, the menu item corresponding
@@ -1580,7 +1580,7 @@ function menu_set_active_trail($new_trail = NULL) {
     // Make sure the current page is in the trail (needed for the page title),
     // but exclude tabs and the front page.
     $last = count($trail) - 1;
-    if ($trail[$last]['href'] != $item['href'] && !(bool)($item['type'] & MENU_IS_LOCAL_TASK) && !drupal_is_front_page()) {
+    if ($item && $trail[$last]['href'] != $item['href'] && !(bool)($item['type'] & MENU_IS_LOCAL_TASK) && !drupal_is_front_page()) {
       $trail[] = $item;
     }
   }

--- a/modules/block/block.admin.inc
+++ b/modules/block/block.admin.inc
@@ -160,7 +160,7 @@ function block_admin_configure(&$form_state, $module = NULL, $delta = 0) {
     '#title' => t('Block title'),
     '#maxlength' => 64,
     '#description' => $module == 'block' ? t('The title of the block as shown to the user.') : t('Override the default title for the block. Use <em>&lt;none&gt;</em> to display no title, or leave blank to use the default block title.'),
-    '#default_value' => $edit['title'],
+    '#default_value' => $edit ? $edit['title'] : NULL,
     '#weight' => -18,
   );
 
@@ -193,7 +193,7 @@ function block_admin_configure(&$form_state, $module = NULL, $delta = 0) {
       t('Hide this block by default but let individual users show it.')
     ),
     '#description' => t('Allow individual users to customize the visibility of this block in their account settings.'),
-    '#default_value' => $edit['custom'],
+    '#default_value' => $edit ? $edit['custom'] : NULL,
   );
 
   // Role-based visibility settings
@@ -227,7 +227,7 @@ function block_admin_configure(&$form_state, $module = NULL, $delta = 0) {
   );
   $access = user_access('use PHP for block visibility');
 
-  if ($edit['visibility'] == 2 && !$access) {
+  if ($edit && $edit['visibility'] == 2 && !$access) {
     $form['page_vis_settings'] = array();
     $form['page_vis_settings']['visibility'] = array('#type' => 'value', '#value' => 2);
     $form['page_vis_settings']['pages'] = array('#type' => 'value', '#value' => $edit['pages']);
@@ -244,12 +244,12 @@ function block_admin_configure(&$form_state, $module = NULL, $delta = 0) {
       '#type' => 'radios',
       '#title' => t('Show block on specific pages'),
       '#options' => $options,
-      '#default_value' => $edit['visibility'],
+      '#default_value' =>  $edit ? $edit['visibility'] : NULL,
     );
     $form['page_vis_settings']['pages'] = array(
       '#type' => 'textarea',
       '#title' => t('Pages'),
-      '#default_value' => $edit['pages'],
+      '#default_value' => $edit ? $edit['pages'] : NULL,
       '#description' => $description,
     );
   }

--- a/modules/book/book.module
+++ b/modules/book/book.module
@@ -860,7 +860,7 @@ function _book_toc_recurse($tree, $indent, &$toc, $exclude, $depth_limit) {
  * @return
  *   An array of mlid, title pairs for use as options for selecting a book page.
  */
-function book_toc($bid, $exclude = array(), $depth_limit) {
+function book_toc($bid, $exclude, $depth_limit) {
 
   $tree = menu_tree_all_data(book_menu_name($bid));
   $toc = array();

--- a/modules/comment/comment.admin.inc
+++ b/modules/comment/comment.admin.inc
@@ -33,7 +33,7 @@ function comment_admin($type = 'new') {
  * @see comment_admin_overview_submit()
  * @see theme_comment_admin_overview()
  */
-function comment_admin_overview($type = 'new', $arg) {
+function comment_admin_overview($type, $arg) {
   // build an 'Update options' form
   $form['options'] = array(
     '#type' => 'fieldset', '#title' => t('Update options'),

--- a/modules/contact/contact.admin.inc
+++ b/modules/contact/contact.admin.inc
@@ -22,7 +22,7 @@ function contact_admin_categories() {
 /**
  * Category edit page.
  */
-function contact_admin_edit($form_state = array(), $op, $contact = NULL) {
+function contact_admin_edit($form_state, $op, $contact = NULL) {
 
   if (empty($contact) || $op == 'add') {
     $contact = array(

--- a/modules/dblog/dblog.admin.inc
+++ b/modules/dblog/dblog.admin.inc
@@ -191,8 +191,10 @@ function dblog_build_filter_query() {
   foreach ($_SESSION['dblog_overview_filter'] as $key => $filter) {
     $filter_where = array();
     foreach ($filter as $value) {
-      $filter_where[] = $filters[$key]['where'];
-      $args[] = $value;
+      if (isset($filters[$key]['where'])) {
+        $filter_where[] = $filters[$key]['where'];
+        $args[] = $value;
+      }
     }
     if (!empty($filter_where)) {
       $where[] = '('. implode(' OR ', $filter_where) .')';

--- a/modules/forum/forum.module
+++ b/modules/forum/forum.module
@@ -582,7 +582,7 @@ function forum_get_topics($tid, $sortby, $forum_per_page) {
   );
 
   $order = _forum_get_topic_order($sortby);
-  for ($i = 0; $i < count($forum_topic_list_header); $i++) {
+  for ($i = 1; $i < count($forum_topic_list_header); $i++) {
     if ($forum_topic_list_header[$i]['field'] == $order['field']) {
       $forum_topic_list_header[$i]['sort'] = $order['sort'];
     }

--- a/modules/user/user.module
+++ b/modules/user/user.module
@@ -1533,7 +1533,7 @@ function user_edit_form(&$form_state, $uid, $edit, $register = FALSE) {
   if ($register || ($GLOBALS['user']->uid == $uid && user_access('change own username')) || $admin) {
     $form['account']['name'] = array('#type' => 'textfield',
       '#title' => t('Username'),
-      '#default_value' => $edit['name'],
+      '#default_value' => isset($edit['name']) ? $edit['name'] : NULL,
       '#maxlength' => USERNAME_MAX_LENGTH,
       '#description' => t('Spaces are allowed; punctuation is not allowed except for periods, hyphens, and underscores.'),
       '#required' => TRUE,
@@ -1541,7 +1541,7 @@ function user_edit_form(&$form_state, $uid, $edit, $register = FALSE) {
   }
   $form['account']['mail'] = array('#type' => 'textfield',
     '#title' => t('E-mail address'),
-    '#default_value' => $edit['mail'],
+    '#default_value' => isset($edit['mail']) ? $edit['mail'] : NULL,
     '#maxlength' => EMAIL_MAX_LENGTH,
     '#description' => t('A valid e-mail address. All e-mails from the system will be sent to this address. The e-mail address is not made public and will only be used if you wish to receive a new password or wish to receive certain news or notifications by e-mail.'),
     '#required' => TRUE,


### PR DESCRIPTION
These are all notices which I encountered while running simpletest-D6 (https://github.com/rmuit/simpletest) on PHP7.4 / PHP8.0. Regular (non-Pressflow) Drupal will never see them because drupal_error_handler() ignores PHP Notice / Deprecated messages. Eek.

But I figured I'd scoop them up into 1 PR for those interested.

None of these fixes cover up bugs; every notice happens in cases where the 'input' value is legit.

Most of them are simple one-line fixes, except:
* The fix to _drupal_build_css_path() which I found in https://www.drupal.org/project/drupal/issues/3084953 makes the code look strange / doesn't explain what is going on, so I changed it and added PHPDoc. (_drupal_build_css_path() is a preg_replace callback.)
* I suspect db_result() was never meant to be called inside of a foreach loop, because: see the comments I made (and the code). So arguably the callers are 'buggy.' However there are so many 'buggy' callers that I opted to fix and comment db_result() instead. (Core block.module does it, but also I found the following modules on my own file system doing it: boost, comment_revisions, ibiblio, imagecache, masquerade, path_redirect, pathauto, salesforce, sf_webform, simpletest, twitter, ubercart, views_bulk_operations, weblinks, xmlsitemap.)
