### PR TITLE
D6 doesn't have 'bypass node access', use 'administer nodes' instead.

### DIFF
--- a/includes/menu.inc
+++ b/includes/menu.inc
@@ -1003,7 +1003,7 @@ function menu_tree_collect_node_links(&$tree, &$node_links) {
  */
 function menu_tree_check_access(&$tree, $node_links = array()) {
 
-  if ($node_links && (user_access('access content') || user_access('bypass node access'))) {
+  if ($node_links && (user_access('access content') || user_access('administer nodes'))) {
     // Use db_rewrite_sql to evaluate view access without loading each full node.
     $nids = array_keys($node_links);
     $placeholders = '%d'. str_repeat(', %d', count($nids) - 1);
@@ -1011,7 +1011,7 @@ function menu_tree_check_access(&$tree, $node_links = array()) {
     // nodes is administering the menu, included the unpublished nodes in the
     // tree, with a special flag so that the Menu module can label them.
     // Otherwise, exclude these nodes from the tree.
-    if (!empty($GLOBALS['menu_admin']) && user_access('bypass node access')) {
+    if (!empty($GLOBALS['menu_admin']) && user_access('administer nodes')) {
       $sql = "SELECT n.nid, n.status FROM {node} n WHERE n.nid IN (". $placeholders .")";
     }
     else {


### PR DESCRIPTION
Per my comments here: https://www.drupal.org/project/d6lts/issues/2966553#comment-14166368

D6 does not have a 'bypass node access' permission, so these lines effectively limit to user 1.

D7 split 'bypass node access' off of 'administer nodes'  in #305566  - https://www.drupal.org/node/305566
Commit: https://github.com/drupal/drupal/commit/89b0570d707e7a895a832f877dcdc74b68d26d42

A better fix would be to backport the 'bypass node access' permission, but in lieu of that, we should use the D6 equivalent.