### PR TITLE
PHP 8 Update for bootstrap.inc

### DIFF
--- a/includes/bootstrap.inc
+++ b/includes/bootstrap.inc
@@ -532,7 +532,7 @@ function drupal_get_filename($type, $name, $filename = NULL) {
     // Fallback to searching the filesystem if the database connection is
     // not established or the requested file is not found.
     $config = conf_path();
-    $dir = (($type == 'theme_engine') ? 'themes/engines' : "${type}s");
+    $dir = (($type == 'theme_engine') ? 'themes/engines' : "{$type}s");
     $file = (($type == 'theme_engine') ? "$name.engine" : "$name.$type");
 
     foreach (array("$config/$dir/$file", "$config/$dir/$name/$file", "$dir/$file", "$dir/$name/$file") as $file) {


### PR DESCRIPTION
Updated syntax / variable definition to the PHP 8 version standard.

Makes the bootstrap.inc run on php 8.2  

old format was ${VAR}  , new PHP8 format is  {$VAR} 

Simple , one letter change makes it work :-)